### PR TITLE
feat(cheats): add CyberFoil cheat manager and sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The project is still in development, expect things to break or change without no
   - [Environment variables](#environment-variables)
   - [Python](#using-python)
   - [CyberFoil setup](#cyberfoil-setup)
+  - [Cheats](#cheats)
   - [Save backups](#save-backups-save-sync)
   - [Requests](#requests)
 - [Usage](#usage)
@@ -151,6 +152,20 @@ In CyberFoil, set the AeroFoil Remote URL in Settings:
  - URL: `http://<server-ip>:8465` (or `https://` if using an SSL-enabled reverse proxy) and port 443
  - Username: username as created in AeroFoil settings (if the remote is private)
  - Password: password as created in AeroFoil settings (if the remote is private)
+
+## Cheats
+
+AeroFoil includes an admin Cheat Manager under **Content → Cheats** for Atmosphère-compatible cheat files. Cheats are associated with a title ID and build ID, then stored as `<build-id>.txt`.
+
+- Choose a title from the library search or enter a title ID manually for a title that is not yet in the library.
+- Add a cheat by uploading a `.txt` file or pasting its text directly. An optional note is shown in the manager list.
+- Download or delete individual cheat files from the list.
+- Optionally sync a ZIP archive. The importer recognizes common structures, including `<title-id>/cheats/<build-id>.txt` and `atmosphere/contents/<title-id>/cheats/<build-id>.txt`.
+- The [switch-cheats-db latest `titles_complete.zip`](https://github.com/HamletDuFromage/switch-cheats-db/releases/latest/download/titles_complete.zip) archive is a compatible sync source.
+
+Enable **Show the Cheats section in CyberFoil** at the top of the manager and save the setting to advertise a versioned **Cheats** section to CyberFoil. Only cheats whose title has an owned base title in the library are included in that section.
+
+Cheat management is admin-only. In **Users**, enable the **Cheats** permission for each account that may browse or download cheats from a private shop. Disabling it hides the CyberFoil Cheats section and denies the cheat APIs for that user. Public shops cannot apply this permission because requests have no per-user identity.
 
 ## Save backups (Save Sync)
 AeroFoil supports per-user save backup management when the user has the **Backup** flag enabled:

--- a/app/app.py
+++ b/app/app.py
@@ -36,6 +36,7 @@ from app.utils import *
 from app.library import *
 from app.library import _get_nsz_runner, _ensure_unique_path
 from app import titledb
+from app import cheats
 from app.title_requests import create_title_request, list_requests
 import requests
 import re
@@ -715,7 +716,7 @@ def _get_titledb_aware_state_token():
         titledb_token = str(titles.get_titledb_cache_token() or 'missing')
     except Exception:
         titledb_token = 'missing'
-    return f"{library_token}::{titledb_token}"
+    return f"{library_token}::{titledb_token}::{cheats.cheat_state_token()}"
 
 
 def _get_cached_titles_total(cache_key):
@@ -1498,21 +1499,75 @@ def _build_shop_sections_payload(limit, full_catalog=False):
         if all_limit is not None:
             all_items = all_items[:all_limit]
 
+        sections = [
+            {'id': 'new', 'title': 'New', 'items': new_items},
+            {'id': 'recommended', 'title': 'Recommended', 'items': recommended_items},
+            {'id': 'updates', 'title': 'Updates', 'items': update_items},
+            {'id': 'dlc', 'title': 'DLC', 'items': dlc_items},
+            {
+                'id': 'all',
+                'title': 'All',
+                'items': all_items,
+                'total': all_total,
+                'truncated': len(all_items) < all_total
+            }
+        ]
+        if full_catalog and bool((app_settings.get('cheats') or {}).get('enabled', True)):
+            cheat_items = _build_cyberfoil_cheat_items()
+            sections.append({
+                'id': 'cheats',
+                'title': 'Cheats',
+                'items': cheat_items,
+                'total': len(cheat_items),
+                'truncated': False,
+            })
         return {
-            'sections': [
-                {'id': 'new', 'title': 'New', 'items': new_items},
-                {'id': 'recommended', 'title': 'Recommended', 'items': recommended_items},
-                {'id': 'updates', 'title': 'Updates', 'items': update_items},
-                {'id': 'dlc', 'title': 'DLC', 'items': dlc_items},
-                {
-                    'id': 'all',
-                    'title': 'All',
-                    'items': all_items,
-                    'total': all_total,
-                    'truncated': len(all_items) < all_total
-                }
-            ]
+            'sections': sections
         }
+
+
+def _build_cyberfoil_cheat_items():
+    """Return versioned cheat entries for the CyberFoil catalogue.
+
+    Entries deliberately carry a normal URL/size pair, making them browseable by
+    current clients while providing the title/build metadata newer clients need to
+    place a file in Atmosphere's cheats directory.
+    """
+    owned_title_ids = {
+        str(row[0] or '').upper()
+        for row in (
+            db.session.query(Titles.title_id)
+            .join(Apps, Apps.title_id == Titles.id)
+            .filter(Apps.owned.is_(True), Apps.app_type == APP_TYPE_BASE)
+            .distinct()
+            .all()
+        )
+    }
+    items = []
+    with titles.titledb_session() as titledb_loaded:
+        for cheat in cheats.list_cheats():
+            title_id = cheat['title_id']
+            if title_id not in owned_title_ids:
+                continue
+            info = titles.get_game_info(title_id) if titledb_loaded else {}
+            name = str((info or {}).get('name') or title_id)
+            build_id = cheat['build_id']
+            icon_url = f'/api/shop/icon/{title_id}'
+            items.append({
+                'name': f'{name} — {build_id}',
+                'title_name': name,
+                'title_id': title_id,
+                'build_id': build_id,
+                'app_type': 'CHEAT',
+                'category': 'Cheats',
+                'icon_url': icon_url,
+                'iconUrl': icon_url,
+                'url': f'/api/cheats/{title_id}/{build_id}',
+                'size': int(cheat['size']),
+                'filename': f'{build_id}.txt',
+                'note': str(cheat.get('note') or ''),
+            })
+    return sorted(items, key=lambda item: (item['title_name'].lower(), item['build_id']))
 
 def _refresh_shop_sections_cache(limit):
     global shop_sections_refresh_running
@@ -2882,6 +2937,35 @@ def _is_shop_client_request():
     return _has_tinfoil_header_set() or _is_shop_client_allowed_for_external()
 
 
+def _request_has_cheat_access():
+    """Resolve the current shop user's cheat permission without changing auth flow."""
+    try:
+        if current_user.is_authenticated:
+            return bool(current_user.has_access('cheats'))
+    except Exception:
+        pass
+    username = _get_request_user()
+    if username:
+        user = User.query.filter_by(user=username).first()
+        return bool(user and user.has_access('cheats'))
+    # A public shop has no per-user identity to apply a user permission to.
+    return bool((app_settings.get('shop') or {}).get('public', False))
+
+
+def _filter_cheat_section(payload, allowed):
+    if allowed:
+        return payload
+    sections = (payload or {}).get('sections')
+    if not isinstance(sections, list):
+        return payload
+    filtered = [section for section in sections if str((section or {}).get('id') or '') != 'cheats']
+    if len(filtered) == len(sections):
+        return payload
+    result = dict(payload)
+    result['sections'] = filtered
+    return result
+
+
 def _log_access(
     kind,
     title_id=None,
@@ -3780,6 +3864,15 @@ def upload_page():
     return render_template(
         'upload.html',
         title='Upload',
+        admin_account_created=admin_account_created())
+
+
+@app.route('/cheats')
+@access_required('admin')
+def cheats_page():
+    return render_template(
+        'cheats.html',
+        title='Cheats',
         admin_account_created=admin_account_created())
 
 
@@ -6657,6 +6750,18 @@ def get_title_details_api():
 
     game = None
     if row:
+        title_cheats = []
+        if _request_has_cheat_access():
+            title_cheats = [
+                {
+                    'build_id': cheat['build_id'],
+                    'size': int(cheat['size']),
+                    'note': str(cheat.get('note') or ''),
+                    'url': f"/api/cheats/{row.title_id}/{cheat['build_id']}",
+                }
+                for cheat in cheats.list_cheats()
+                if cheat['title_id'] == row.title_id
+            ]
         with titles.titledb_session():
             title_info = titles.get_game_info(row.title_id) or {}
             app_info = title_info if row.app_type == APP_TYPE_BASE else (titles.get_game_info(row.app_id) or title_info)
@@ -6711,6 +6816,7 @@ def get_title_details_api():
                     item for item in dlc_items
                     if not item.get('owned') and not item.get('ignored')
                 ],
+                'cheats': title_cheats,
             }
             if row.app_type == APP_TYPE_BASE:
                 versions = []
@@ -7259,14 +7365,120 @@ def shop_sections_api():
     # section caches above stay user-agnostic.
     cap, block_unrated = _user_rating_cap()
     response_payload = _filter_sections_payload(payload, cap, block_unrated)
+    cheat_access = _request_has_cheat_access()
+    if is_cyberfoil:
+        response_payload = _filter_cheat_section(response_payload, cheat_access)
 
     return _respond_with_shop_payload(
         response_payload,
         cache_kind='sections',
         cache_limit=cache_limit,
         full_catalog=is_cyberfoil,
-        filter_token=(cap, block_unrated),
+        filter_token=(cap, block_unrated, cheat_access),
     )
+
+
+@app.get('/api/cheats')
+@access_required('shop')
+def list_cheats_api():
+    if not _request_has_cheat_access():
+        return jsonify({'success': False, 'error': 'Cheat access is disabled for this account.'}), 403
+    return jsonify({'success': True, 'cheats': _build_cyberfoil_cheat_items()})
+
+
+@app.get('/api/cheats/<title_id>/<build_id>')
+@tinfoil_access
+def download_cheat_api(title_id, build_id):
+    if not _request_has_cheat_access():
+        return tinfoil_error('Cheat access is disabled for this account.')
+    data = cheats.read_cheat(title_id, build_id)
+    if data is None:
+        return jsonify({'success': False, 'error': 'cheat_not_found'}), 404
+    normalized_build_id = cheats.normalize_build_id(build_id)
+    response = Response(data, mimetype='text/plain')
+    response.headers['Content-Disposition'] = (
+        f'attachment; filename="{normalized_build_id}.txt"'
+    )
+    return response
+
+
+@app.post('/api/cheats')
+@access_required('admin')
+def upload_cheat_api():
+    upload = request.files.get('file')
+    pasted_content = request.form.get('content')
+    note = str(request.form.get('note') or '').strip()
+    if len(note) > 1000:
+        return jsonify({'success': False, 'error': 'Cheat note must be 1000 characters or less.'}), 400
+    if upload is not None and upload.filename:
+        cheat_data = upload.read()
+    elif pasted_content is not None and pasted_content.strip():
+        cheat_data = pasted_content.encode('utf-8')
+    else:
+        return jsonify({'success': False, 'error': 'Provide a cheat file or paste cheat content.'}), 400
+    try:
+        cheat = cheats.save_cheat(
+            request.form.get('title_id'), request.form.get('build_id'), cheat_data)
+        cheat['note'] = cheats.set_cheat_note(
+            cheat['title_id'], cheat['build_id'], note)
+    except ValueError as exc:
+        return jsonify({'success': False, 'error': str(exc)}), 400
+    _invalidate_shop_root_cache()
+    with shop_sections_cache_lock:
+        shop_sections_cache['payload'] = None
+        shop_sections_cache['encrypted'] = {}
+    return jsonify({'success': True, 'cheat': cheat})
+
+
+@app.delete('/api/cheats/<title_id>/<build_id>')
+@access_required('admin')
+def delete_cheat_api(title_id, build_id):
+    if not cheats.delete_cheat(title_id, build_id):
+        return jsonify({'success': False, 'error': 'cheat_not_found'}), 404
+    _invalidate_shop_root_cache()
+    with shop_sections_cache_lock:
+        shop_sections_cache['payload'] = None
+        shop_sections_cache['encrypted'] = {}
+    return jsonify({'success': True})
+
+
+@app.post('/api/cheats/sync')
+@access_required('admin')
+def sync_cheats_api():
+    data = request.get_json(silent=True) or {}
+    sync_url = str(data.get('url') or (app_settings.get('cheats') or {}).get('sync_url') or '').strip()
+    if not sync_url.lower().startswith(('https://', 'http://')):
+        return jsonify({'success': False, 'error': 'Configure an HTTP(S) cheat ZIP URL first.'}), 400
+    try:
+        response = requests.get(sync_url, timeout=(10, 90))
+        response.raise_for_status()
+        result = cheats.import_zip(response.content)
+    except requests.RequestException as exc:
+        return jsonify({'success': False, 'error': f'Cheat sync failed: {exc}'}), 502
+    except ValueError as exc:
+        return jsonify({'success': False, 'error': str(exc)}), 400
+    _invalidate_shop_root_cache()
+    with shop_sections_cache_lock:
+        shop_sections_cache['payload'] = None
+        shop_sections_cache['encrypted'] = {}
+    return jsonify({'success': True, **result})
+
+
+@app.post('/api/settings/cheats')
+@access_required('admin')
+def set_cheats_settings_api():
+    data = request.get_json(silent=True) or {}
+    updates = {}
+    if 'enabled' in data:
+        updates['enabled'] = bool(data.get('enabled'))
+    if 'sync_url' in data:
+        updates['sync_url'] = str(data.get('sync_url') or '').strip()
+    set_cheats_settings(updates)
+    reload_conf()
+    with shop_sections_cache_lock:
+        shop_sections_cache['payload'] = None
+        shop_sections_cache['encrypted'] = {}
+    return jsonify({'success': True})
 
 
 @app.get('/api/shop/icon/<title_id>')

--- a/app/auth.py
+++ b/app/auth.py
@@ -715,7 +715,7 @@ def normalize_max_rating(value):
     return rating if rating in ESRB_VALID_AGES else None
 
 
-def create_or_update_user(username, password, admin_access=False, shop_access=False, backup_access=False, max_rating=None):
+def create_or_update_user(username, password, admin_access=False, shop_access=False, backup_access=False, cheat_access=True, max_rating=None):
     """
     Create a new user or update an existing user with the given credentials and access rights.
     """
@@ -726,6 +726,7 @@ def create_or_update_user(username, password, admin_access=False, shop_access=Fa
         user.admin_access = admin_access
         user.shop_access = shop_access
         user.backup_access = backup_access
+        user.cheat_access = cheat_access
         user.max_rating = max_rating
         if getattr(user, 'frozen', False) and admin_access:
             user.frozen = False
@@ -733,7 +734,7 @@ def create_or_update_user(username, password, admin_access=False, shop_access=Fa
         user.password = generate_password_hash(password, method='scrypt')
     else:
         logger.info(f'Creating new user {username}')
-        new_user = User(user=username, password=generate_password_hash(password, method='scrypt'), admin_access=admin_access, shop_access=shop_access, backup_access=backup_access, max_rating=max_rating)
+        new_user = User(user=username, password=generate_password_hash(password, method='scrypt'), admin_access=admin_access, shop_access=shop_access, backup_access=backup_access, cheat_access=cheat_access, max_rating=max_rating)
         db.session.add(new_user)
     db.session.commit()
     _invalidate_admin_exists_cache()
@@ -750,11 +751,13 @@ def init_user_from_environment(environment_name, admin=False):
             admin_access = True
             shop_access = True
             backup_access = True
+            cheat_access = True
         else:
             logger.info('Initializing a regular user from environment variable...')
             admin_access = False
             shop_access = True
             backup_access = False
+            cheat_access = True
 
         if not admin:
             existing_admin = admin_account_created()
@@ -762,7 +765,7 @@ def init_user_from_environment(environment_name, admin=False):
                 logger.error(f'Error creating user {username}, first account created must be admin')
                 return
 
-        create_or_update_user(username, password, admin_access, shop_access, backup_access)
+        create_or_update_user(username, password, admin_access, shop_access, backup_access, cheat_access)
 
 def init_users(app):
     with app.app_context():
@@ -866,6 +869,7 @@ def get_users():
             User.admin_access,
             User.shop_access,
             User.backup_access,
+            User.cheat_access,
             User.frozen,
             User.frozen_message,
             User.max_rating,
@@ -1068,13 +1072,14 @@ def update_user():
     admin_access = data.get('admin_access')
     shop_access = data.get('shop_access')
     backup_access = data.get('backup_access')
+    cheat_access = data.get('cheat_access')
     max_rating = normalize_max_rating(data.get('max_rating'))
 
     if not user_id:
         errors.append('Missing user id.')
     if not username:
         errors.append('Username is required.')
-    if admin_access is None or shop_access is None or backup_access is None:
+    if admin_access is None or shop_access is None or backup_access is None or cheat_access is None:
         errors.append('Missing access configuration.')
 
     user = User.query.filter_by(id=user_id).first() if not errors else None
@@ -1097,10 +1102,12 @@ def update_user():
         if admin_access:
             shop_access = True
             backup_access = True
+            cheat_access = True
         user.user = username
         user.admin_access = admin_access
         user.shop_access = shop_access
         user.backup_access = backup_access
+        user.cheat_access = cheat_access
         user.max_rating = max_rating
         if getattr(user, 'frozen', False) and admin_access:
             user.frozen = False
@@ -1176,9 +1183,11 @@ def signup_post():
     if admin_access:
         shop_access = True
         backup_access = True
+        cheat_access = True
     else:
         shop_access = data['shop_access']
         backup_access = data['backup_access']
+        cheat_access = data.get('cheat_access', True)
 
     user = User.query.filter_by(user=username).first() # if this returns a user, then the user already exists in database
     
@@ -1198,7 +1207,7 @@ def signup_post():
         return jsonify(resp)
 
     # create a new user with the form data. Hash the password so the plaintext version isn't saved.
-    create_or_update_user(username, password, admin_access, shop_access, backup_access, max_rating=max_rating)
+    create_or_update_user(username, password, admin_access, shop_access, backup_access, cheat_access, max_rating=max_rating)
     
     logger.info(f'Successfully created user {username}.')
 

--- a/app/cheats.py
+++ b/app/cheats.py
@@ -1,0 +1,242 @@
+"""Storage and import helpers for Atmosphere cheat files.
+
+Cheats are kept outside library paths so scans never mistake them for installable
+content.  The layout mirrors Atmosphere: ``<title id>/<build id>.txt``.
+"""
+
+import hashlib
+import io
+import json
+import os
+import re
+import zipfile
+
+from app.constants import DATA_DIR
+
+
+CHEATS_DIR = os.path.join(DATA_DIR, 'cheats')
+TITLE_ID_RE = re.compile(r'^[0-9A-F]{16}$')
+BUILD_ID_RE = re.compile(r'^[0-9A-F]{16,64}$')
+MAX_CHEAT_FILE_BYTES = 2 * 1024 * 1024
+MAX_SYNC_ARCHIVE_BYTES = 128 * 1024 * 1024
+
+
+def normalize_title_id(value):
+    value = str(value or '').strip().upper()
+    return value if TITLE_ID_RE.fullmatch(value) else None
+
+
+def normalize_build_id(value):
+    value = str(value or '').strip().upper()
+    return value if BUILD_ID_RE.fullmatch(value) else None
+
+
+def _cheat_path(title_id, build_id):
+    return os.path.join(CHEATS_DIR, title_id, f'{build_id}.txt')
+
+
+def _metadata_path():
+    return os.path.join(CHEATS_DIR, 'metadata.json')
+
+
+def _load_metadata():
+    try:
+        with open(_metadata_path(), 'r', encoding='utf-8') as handle:
+            data = json.load(handle)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_metadata(metadata):
+    os.makedirs(CHEATS_DIR, exist_ok=True)
+    with open(_metadata_path(), 'w', encoding='utf-8') as handle:
+        json.dump(metadata, handle, indent=2, sort_keys=True)
+
+
+def _metadata_key(title_id, build_id):
+    return f'{title_id}/{build_id}'
+
+
+def _safe_cheat_text(data):
+    if not isinstance(data, (bytes, bytearray)):
+        raise ValueError('Cheat data must be a text file.')
+    if not data or len(data) > MAX_CHEAT_FILE_BYTES:
+        raise ValueError('Cheat file must be between 1 byte and 2 MB.')
+    try:
+        data.decode('utf-8-sig')
+    except UnicodeDecodeError as exc:
+        raise ValueError('Cheat file must be UTF-8 text.') from exc
+    return bytes(data)
+
+
+def save_cheat(title_id, build_id, data):
+    title_id = normalize_title_id(title_id)
+    build_id = normalize_build_id(build_id)
+    if not title_id or not build_id:
+        raise ValueError('A 16-character title ID and hexadecimal build ID are required.')
+    data = _safe_cheat_text(data)
+    path = _cheat_path(title_id, build_id)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as handle:
+        handle.write(data)
+    return {
+        'title_id': title_id,
+        'build_id': build_id,
+        'size': len(data),
+        'sha256': hashlib.sha256(data).hexdigest(),
+    }
+
+
+def delete_cheat(title_id, build_id):
+    title_id = normalize_title_id(title_id)
+    build_id = normalize_build_id(build_id)
+    if not title_id or not build_id:
+        return False
+    path = _cheat_path(title_id, build_id)
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        return False
+    try:
+        os.rmdir(os.path.dirname(path))
+    except OSError:
+        pass
+    metadata = _load_metadata()
+    metadata.pop(_metadata_key(title_id, build_id), None)
+    _save_metadata(metadata)
+    return True
+
+
+def list_cheats():
+    result = []
+    metadata = _load_metadata()
+    if not os.path.isdir(CHEATS_DIR):
+        return result
+    for title_id in sorted(os.listdir(CHEATS_DIR)):
+        if not normalize_title_id(title_id):
+            continue
+        title_dir = os.path.join(CHEATS_DIR, title_id)
+        if not os.path.isdir(title_dir):
+            continue
+        for filename in sorted(os.listdir(title_dir)):
+            build_id, extension = os.path.splitext(filename)
+            if extension.lower() != '.txt' or not normalize_build_id(build_id):
+                continue
+            path = os.path.join(title_dir, filename)
+            try:
+                stat = os.stat(path)
+            except OSError:
+                continue
+            result.append({
+                'title_id': title_id,
+                'build_id': build_id.upper(),
+                'size': int(stat.st_size),
+                'updated_at': int(stat.st_mtime),
+                'note': str(metadata.get(_metadata_key(title_id, build_id.upper()), '') or ''),
+            })
+    return result
+
+
+def set_cheat_note(title_id, build_id, note):
+    title_id = normalize_title_id(title_id)
+    build_id = normalize_build_id(build_id)
+    if not title_id or not build_id or not os.path.isfile(_cheat_path(title_id, build_id)):
+        raise ValueError('Cheat file was not found.')
+    note = str(note or '').strip()
+    if len(note) > 1000:
+        raise ValueError('Cheat note must be 1000 characters or less.')
+    metadata = _load_metadata()
+    key = _metadata_key(title_id, build_id)
+    if note:
+        metadata[key] = note
+    else:
+        metadata.pop(key, None)
+    _save_metadata(metadata)
+    return note
+
+
+def cheat_state_token():
+    entries = []
+    for cheat in list_cheats():
+        entries.append('%s:%s:%s:%s' % (
+            cheat['title_id'], cheat['build_id'], cheat['size'], cheat['updated_at']))
+    return hashlib.sha256('|'.join(entries).encode('utf-8')).hexdigest()
+
+
+def read_cheat(title_id, build_id):
+    title_id = normalize_title_id(title_id)
+    build_id = normalize_build_id(build_id)
+    if not title_id or not build_id:
+        return None
+    path = _cheat_path(title_id, build_id)
+    try:
+        with open(path, 'rb') as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def _archive_cheat_identity(member_name):
+    parts = [part.upper() for part in member_name.replace('\\', '/').split('/') if part and part not in ('.', '..')]
+    if not parts or not member_name.lower().endswith('.txt'):
+        return None, None
+
+    # Sources commonly use either <title>/<build>.txt or
+    # <title>/cheats/<build>.txt (including the Atmosphere contents layout).
+    # Also accept IDs wrapped in brackets or followed by a descriptive suffix.
+    def _extract_identifier(value, validator, minimum, maximum):
+        normalized = str(value or '').upper()
+        direct = validator(normalized)
+        if direct:
+            return direct
+        match = re.search(
+            rf'(?<![0-9A-F])([0-9A-F]{{{minimum},{maximum}}})(?![0-9A-F])',
+            normalized,
+        )
+        return validator(match.group(1)) if match else None
+
+    build_id = _extract_identifier(
+        os.path.splitext(parts[-1])[0], normalize_build_id, 16, 64)
+    title_id = next(
+        (
+            _extract_identifier(part, normalize_title_id, 16, 16)
+            for part in reversed(parts[:-1])
+            if _extract_identifier(part, normalize_title_id, 16, 16)
+        ),
+        None,
+    )
+    return title_id, build_id
+
+
+def import_zip(data):
+    if not isinstance(data, (bytes, bytearray)) or not data or len(data) > MAX_SYNC_ARCHIVE_BYTES:
+        raise ValueError('Cheat archive must be between 1 byte and 128 MB.')
+    imported = 0
+    skipped = 0
+    ignored = 0
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile as exc:
+        raise ValueError('The cheat source did not return a valid ZIP archive.') from exc
+    with archive:
+        for info in archive.infolist():
+            if info.is_dir():
+                ignored += 1
+                continue
+            if info.file_size > MAX_CHEAT_FILE_BYTES:
+                skipped += 1
+                continue
+            title_id, build_id = _archive_cheat_identity(info.filename)
+            if not title_id or not build_id:
+                # Archives such as switch-cheats-db include title-description
+                # text files alongside cheats; these are not errors.
+                ignored += 1
+                continue
+            try:
+                save_cheat(title_id, build_id, archive.read(info))
+            except (OSError, ValueError):
+                skipped += 1
+                continue
+            imported += 1
+    return {'imported': imported, 'skipped': skipped, 'ignored': ignored}

--- a/app/constants.py
+++ b/app/constants.py
@@ -164,6 +164,12 @@ DEFAULT_SETTINGS = {
         "host": "",
         "hauth": "",
     },
+    "cheats": {
+        "enabled": True,
+        # Optional URL to a ZIP archive whose entries include
+        # <title-id>/<build-id>.txt.  Leave empty to use manual imports only.
+        "sync_url": "",
+    },
     "content_filter": {
         # When a user has an age cap (max_rating) set, also hide/block titles
         # that have no known rating (homebrew, unidentified files, or titles

--- a/app/db.py
+++ b/app/db.py
@@ -181,6 +181,7 @@ class User(UserMixin, db.Model):
     admin_access = db.Column(db.Boolean)
     shop_access = db.Column(db.Boolean)
     backup_access = db.Column(db.Boolean)
+    cheat_access = db.Column(db.Boolean, nullable=False, default=True)
     frozen = db.Column(db.Boolean, default=False)
     frozen_message = db.Column(db.String)
     # ESRB age cap (TitleDB minimum-age int). NULL = unrestricted.
@@ -200,6 +201,9 @@ class User(UserMixin, db.Model):
 
     def has_backup_access(self):
         return self.backup_access
+
+    def has_cheat_access(self):
+        return bool(self.cheat_access) and self.has_shop_access()
     
     def has_admin_access(self):
         return self.admin_access
@@ -211,6 +215,8 @@ class User(UserMixin, db.Model):
             return self.has_shop_access()
         elif access == 'backup':
             return self.has_backup_access()
+        elif access == 'cheats':
+            return self.has_cheat_access()
 
 
 class TitleRequests(db.Model):

--- a/app/migrations/versions/d8e7f6a5b4c3_add_user_cheat_access.py
+++ b/app/migrations/versions/d8e7f6a5b4c3_add_user_cheat_access.py
@@ -1,0 +1,24 @@
+"""Add per-user cheat catalogue access.
+
+Revision ID: d8e7f6a5b4c3
+Revises: c6f8a2d9e1b4, 48e539769ef3
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'd8e7f6a5b4c3'
+down_revision = ('c6f8a2d9e1b4', '48e539769ef3')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.add_column(sa.Column('cheat_access', sa.Boolean(), nullable=False, server_default=sa.true()))
+
+
+def downgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.drop_column('cheat_access')

--- a/app/settings.py
+++ b/app/settings.py
@@ -574,6 +574,16 @@ def _normalize_content_filter_settings(raw_content_filter):
     return merged
 
 
+def _normalize_cheats_settings(raw_cheats):
+    defaults = DEFAULT_SETTINGS.get('cheats', {}) or {}
+    merged = defaults.copy()
+    if isinstance(raw_cheats, dict):
+        merged.update(raw_cheats)
+    merged['enabled'] = _coerce_bool(merged.get('enabled'), default=defaults.get('enabled', True))
+    merged['sync_url'] = str(merged.get('sync_url') or '').strip()
+    return merged
+
+
 def _validate_shop_public_key(public_key_pem):
     key_text = str(public_key_pem or '').strip()
     if not key_text:
@@ -719,6 +729,7 @@ def load_settings(force_reload=False):
         _merge_section('shop')
         _merge_section('titles')
         _merge_section('library')
+        _merge_section('cheats')
         _merge_section('content_filter')
 
         env_trust = _read_env_bool('AEROFOIL_TRUST_PROXY_HEADERS')
@@ -753,6 +764,7 @@ def load_settings(force_reload=False):
         settings['downloads'] = _normalize_download_settings(settings.get('downloads'))
         settings['titles'] = _normalize_titles_settings(settings.get('titles'))
         settings['shop'] = _normalize_shop_settings(settings.get('shop'))
+        settings['cheats'] = _normalize_cheats_settings(settings.get('cheats'))
         settings['content_filter'] = _normalize_content_filter_settings(settings.get('content_filter'))
         settings['library']['conversion_staging_dir'] = _normalize_conversion_staging_dir(
             settings['library'].get('conversion_staging_dir')
@@ -778,6 +790,16 @@ def set_security_settings(data):
     settings.setdefault('security', {})
     settings['security'].update(data or {})
     settings['security'] = _normalize_security_settings(settings.get('security'))
+    with open(CONFIG_FILE, 'w') as yaml_file:
+        yaml.dump(settings, yaml_file)
+    _invalidate_settings_cache()
+
+
+def set_cheats_settings(data):
+    settings = load_settings(force_reload=True)
+    settings.setdefault('cheats', {})
+    settings['cheats'].update(data or {})
+    settings['cheats'] = _normalize_cheats_settings(settings.get('cheats'))
     with open(CONFIG_FILE, 'w') as yaml_file:
         yaml.dump(settings, yaml_file)
     _invalidate_settings_cache()

--- a/app/templates/cheats.html
+++ b/app/templates/cheats.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+{% block content %}
+{% include 'nav.html' %}
+
+<div class="container setting-body mt-3">
+    <h2>Cheats</h2>
+    <p class="text-muted">Manage Atmosphère cheat files for titles in your library. Each build ID is a separate game version.</p>
+
+    <div class="card bg-dark border-secondary mb-3">
+        <div class="card-body">
+            <h5 class="card-title">CyberFoil section</h5>
+            <div class="form-check"><input class="form-check-input" type="checkbox" id="cheatSectionEnabled"><label class="form-check-label" for="cheatSectionEnabled">Show the Cheats section in CyberFoil</label></div>
+            <button id="saveCheatSection" class="btn btn-outline-secondary btn-sm mt-3" type="button">Save CyberFoil setting</button>
+        </div>
+    </div>
+
+    <div class="card bg-dark border-secondary mb-3">
+        <div class="card-body">
+            <h5 class="card-title">Import cheat file</h5>
+            <form id="cheatUploadForm" class="row g-3">
+                <div class="col-md-5">
+                    <label class="form-label" for="cheatTitleSearch">Library title</label>
+                    <input id="cheatTitleSearch" class="form-control" placeholder="Search a library title" autocomplete="off">
+                    <div class="list-group mt-2" id="cheatTitleSearchResults"></div>
+                    <label class="form-label mt-2" for="cheatTitleId">Title ID</label>
+                    <input id="cheatTitleId" class="form-control" maxlength="16" pattern="[0-9A-Fa-f]{16}" placeholder="Select above or enter manually" required>
+                    <div class="form-text">You can enter a title ID directly for a title that is not in the library.</div>
+                </div>
+                <div class="col-md-5"><label class="form-label" for="cheatBuildId">Build ID</label><input id="cheatBuildId" class="form-control" maxlength="64" pattern="[0-9A-Fa-f]{16,64}" required></div>
+                <div class="col-md-5"><label class="form-label" for="cheatFile">Cheat file</label><input id="cheatFile" class="form-control" type="file" accept=".txt,text/plain"><div class="form-text">Upload a file or paste the content.</div></div>
+                <div class="col-md-5"><label class="form-label" for="cheatContent">Cheat content</label><textarea id="cheatContent" class="form-control font-monospace" rows="5" placeholder="[Infinite Example]\n04000000 00000000 00000001"></textarea></div>
+                <div class="col-12"><label class="form-label" for="cheatNote">Note <span class="text-muted">(optional)</span></label><input id="cheatNote" class="form-control" maxlength="1000" placeholder="For example: works with update 1.2.0"></div>
+                <div class="col-md-2 d-flex align-items-end"><button class="btn btn-primary w-100" type="submit">Upload</button></div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card bg-dark border-secondary mb-3">
+        <div class="card-body">
+            <h5 class="card-title">Sync source</h5>
+            <p class="small text-muted">Use a ZIP source containing files named <code>&lt;title-id&gt;/&lt;build-id&gt;.txt</code>. Existing matching files are replaced.</p>
+            <div class="input-group"><input id="cheatSyncUrl" class="form-control" type="url" placeholder="https://example.invalid/cheats.zip"><button id="saveCheatSyncSource" class="btn btn-outline-secondary" type="button">Save</button><button id="syncCheats" class="btn btn-primary" type="button">Sync now</button></div>
+        </div>
+    </div>
+
+    <div id="cheatStatus" class="small mb-2" role="status"></div>
+    <div class="table-responsive"><table class="table table-dark table-hover align-middle"><thead><tr><th>Title</th><th>Title ID</th><th>Build ID</th><th>Note</th><th>Size</th><th></th></tr></thead><tbody id="cheatRows"></tbody></table></div>
+</div>
+
+<script>
+function cheatStatus(message, danger) { $('#cheatStatus').toggleClass('text-danger', !!danger).toggleClass('text-success', !danger).text(message || ''); }
+function cheatBytes(bytes) { return bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} KB`; }
+function escapeCheatHtml(text) { return $('<div>').text(text || '').html(); }
+let cheatTitleSearchTimer = null;
+function searchCheatTitles() {
+    const query = String($('#cheatTitleSearch').val() || '').trim();
+    const results = $('#cheatTitleSearchResults').empty();
+    if (cheatTitleSearchTimer) clearTimeout(cheatTitleSearchTimer);
+    if (!query) return;
+    cheatTitleSearchTimer = setTimeout(function() {
+        $.getJSON(`/api/titledb/search?q=${encodeURIComponent(query)}&limit=25`, function(result) {
+            const titles = (result.results || []).filter(item => item && item.in_library === true);
+            titles.forEach(item => {
+                const titleId = String(item.id || '').toUpperCase();
+                const button = $(`<button type="button" class="list-group-item list-group-item-action"><div class="fw-semibold">${escapeCheatHtml(item.name || 'Unrecognized')}</div><div class="small text-muted">${escapeCheatHtml(titleId)}</div></button>`);
+                button.on('click', function() {
+                    $('#cheatTitleId').val(titleId);
+                    $('#cheatTitleSearch').val(item.name || titleId);
+                    results.empty();
+                });
+                results.append(button);
+            });
+            if (!titles.length) results.append('<div class="small text-muted mt-1">No matching library titles. Enter a title ID manually below.</div>');
+        });
+    }, 250);
+}
+function loadCheats() {
+    $.getJSON('/api/cheats', function(result) {
+        const rows = $('#cheatRows').empty();
+        (result.cheats || []).forEach(item => {
+            const row = $('<tr>');
+            row.append($('<td>').text(item.title_name || item.title_id));
+            row.append($('<td>').text(item.title_id)); row.append($('<td>').text(item.build_id)); row.append($('<td>').text(item.note || '—')); row.append($('<td>').text(cheatBytes(item.size || 0)));
+            const download = $('<a class="btn btn-sm btn-outline-secondary me-1">Download</a>')
+                .attr('href', `/api/cheats/${encodeURIComponent(item.title_id)}/${encodeURIComponent(item.build_id)}`)
+                .attr('download', `${item.build_id}.txt`);
+            const remove = $('<button class="btn btn-sm btn-outline-danger">Delete</button>').on('click', function() {
+                $.ajax({url: `/api/cheats/${encodeURIComponent(item.title_id)}/${encodeURIComponent(item.build_id)}`, type: 'DELETE'}).done(loadCheats);
+            });
+            row.append($('<td>').append(download, remove)); rows.append(row);
+        });
+        if (!(result.cheats || []).length) rows.append('<tr><td colspan="6" class="text-muted">No cheats are available for titles in this library.</td></tr>');
+    });
+}
+$('#cheatUploadForm').on('submit', function(event) {
+    event.preventDefault(); const file = $('#cheatFile').prop('files')[0]; const content = String($('#cheatContent').val() || '');
+    if (!file && !content.trim()) { cheatStatus('Upload a file or paste cheat content.', true); return; }
+    const form = new FormData(); form.append('title_id', $('#cheatTitleId').val()); form.append('build_id', $('#cheatBuildId').val()); form.append('note', $('#cheatNote').val()); if (file) form.append('file', file); if (content.trim()) form.append('content', content);
+    $.ajax({url:'/api/cheats', type:'POST', data:form, processData:false, contentType:false}).done(function(result) { cheatStatus('Cheat uploaded.'); $('#cheatUploadForm')[0].reset(); loadCheats(); }).fail(function(xhr) { cheatStatus(xhr.responseJSON?.error || 'Upload failed.', true); });
+});
+$('#cheatTitleSearch').on('input', searchCheatTitles);
+function saveCheatSettings(payload, message) { $.ajax({url:'/api/settings/cheats', type:'POST', contentType:'application/json', data:JSON.stringify(payload)}).done(function() { cheatStatus(message); }).fail(function() { cheatStatus('Could not save cheat settings.', true); }); }
+$('#saveCheatSection').on('click', function() { saveCheatSettings({enabled: $('#cheatSectionEnabled').prop('checked')}, 'CyberFoil setting saved.'); });
+$('#saveCheatSyncSource').on('click', function() { saveCheatSettings({sync_url: $('#cheatSyncUrl').val()}, 'Sync source saved.'); });
+$('#syncCheats').on('click', function() { cheatStatus('Syncing…'); $.ajax({url:'/api/cheats/sync', type:'POST', contentType:'application/json', data:JSON.stringify({url: $('#cheatSyncUrl').val()})}).done(function(result) { cheatStatus(`Imported ${result.imported}; ignored ${result.ignored || 0}; skipped ${result.skipped || 0}.`); loadCheats(); }).fail(function(xhr) { cheatStatus(xhr.responseJSON?.error || 'Sync failed.', true); }); });
+$(function() { $.getJSON('/api/settings', function(result) { const settings = result.cheats || {}; $('#cheatSyncUrl').val(settings.sync_url || ''); $('#cheatSectionEnabled').prop('checked', settings.enabled !== false); }); loadCheats(); });
+</script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2413,9 +2413,41 @@
             `
             : '<div class="text-muted py-2">No DLC entries available.</div>';
 
-        const defaultToDlcTab = String(game.app_type || '').toUpperCase() === 'DLC';
+        const availableCheats = Array.isArray(game.cheats) ? game.cheats : [];
+        const cheatRows = availableCheats.map(cheat => `
+            <tr>
+                <td><code>${escapeHtml(String(cheat.build_id || ''))}</code></td>
+                <td>${escapeHtml(String(cheat.note || '—'))}</td>
+                <td>${formatBytes(cheat.size || 0)}</td>
+                <td class="text-end">
+                    <a class="btn btn-outline-primary btn-sm" href="${escapeHtml(String(cheat.url || ''))}" download>
+                        <i class="bi bi-download"></i> Download
+                    </a>
+                </td>
+            </tr>
+        `).join('');
+        const cheatsTabHtml = availableCheats.length
+            ? `
+                <div class="details-pane-stack">
+                    <div class="details-list-scroll">
+                        <table class="table table-sm table-striped mb-0">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Build ID</th>
+                                    <th scope="col">Note</th>
+                                    <th scope="col">Size</th>
+                                    <th scope="col" class="text-end">Download</th>
+                                </tr>
+                            </thead>
+                            <tbody>${cheatRows}</tbody>
+                        </table>
+                    </div>
+                </div>
+            `
+            : '<div class="text-muted py-2">No cheats are available for this title.</div>';
+        const defaultToDlcTab = dlcList.length > 0 && String(game.app_type || '').toUpperCase() === 'DLC';
 
-        if (dlcList.length > 0) {
+        if (dlcList.length > 0 || availableCheats.length > 0) {
             $('#detailsVersions').html(`
                 ${actionRow}
                 ${customSearchRow}
@@ -2427,11 +2459,20 @@
                             Updates <span class="badge rounded-pill text-bg-secondary ms-1">${versions.length}</span>
                         </button>
                     </li>
+                    ${dlcList.length ? `
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link ${defaultToDlcTab ? 'active' : ''}" id="details-dlc-tab" data-bs-toggle="tab"
+                                data-bs-target="#details-dlc-pane" type="button" role="tab"
+                                aria-controls="details-dlc-pane" aria-selected="${defaultToDlcTab ? 'true' : 'false'}">
+                                DLC <span class="badge rounded-pill text-bg-secondary ms-1">${dlcList.length}</span>
+                            </button>
+                        </li>
+                    ` : ''}
                     <li class="nav-item" role="presentation">
-                        <button class="nav-link ${defaultToDlcTab ? 'active' : ''}" id="details-dlc-tab" data-bs-toggle="tab"
-                            data-bs-target="#details-dlc-pane" type="button" role="tab"
-                            aria-controls="details-dlc-pane" aria-selected="${defaultToDlcTab ? 'true' : 'false'}">
-                            DLC <span class="badge rounded-pill text-bg-secondary ms-1">${dlcList.length}</span>
+                        <button class="nav-link" id="details-cheats-tab" data-bs-toggle="tab"
+                            data-bs-target="#details-cheats-pane" type="button" role="tab"
+                            aria-controls="details-cheats-pane" aria-selected="false">
+                            Cheats <span class="badge rounded-pill text-bg-secondary ms-1">${availableCheats.length}</span>
                         </button>
                     </li>
                 </ul>
@@ -2439,8 +2480,13 @@
                     <div class="tab-pane fade ${defaultToDlcTab ? '' : 'show active'} details-tab-pane" id="details-updates-pane" role="tabpanel" aria-labelledby="details-updates-tab">
                         ${updatesTabHtml}
                     </div>
-                    <div class="tab-pane fade ${defaultToDlcTab ? 'show active' : ''} details-tab-pane" id="details-dlc-pane" role="tabpanel" aria-labelledby="details-dlc-tab">
-                        ${dlcTabHtml}
+                    ${dlcList.length ? `
+                        <div class="tab-pane fade ${defaultToDlcTab ? 'show active' : ''} details-tab-pane" id="details-dlc-pane" role="tabpanel" aria-labelledby="details-dlc-tab">
+                            ${dlcTabHtml}
+                        </div>
+                    ` : ''}
+                    <div class="tab-pane fade details-tab-pane" id="details-cheats-pane" role="tabpanel" aria-labelledby="details-cheats-tab">
+                        ${cheatsTabHtml}
                     </div>
                 </div>
             `);

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -31,7 +31,7 @@
             aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-        {% set content_titles = ['Downloads', 'Upload', 'Manage'] %}
+        {% set content_titles = ['Downloads', 'Upload', 'Manage', 'Cheats'] %}
         {% set backups_titles = ['Save Data Backups'] %}
         {% set admin_titles = ['Activity', 'Users'] %}
         <div class="collapse navbar-collapse" id="navbarNav">
@@ -60,6 +60,7 @@
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item{% if title == 'Downloads' %} active{% endif %}" href="/downloads">Downloads</a></li>
                         <li><a class="dropdown-item{% if title == 'Upload' %} active{% endif %}" href="/upload">Upload</a></li>
+                        <li><a class="dropdown-item{% if title == 'Cheats' %} active{% endif %}" href="/cheats">Cheats</a></li>
                         <li><a class="dropdown-item{% if title == 'Manage' %} active{% endif %}" href="/manage">Manage</a></li>
                     </ul>
                 </li>

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -75,6 +75,10 @@
                                         <label class="form-check-label" for="checkboxNewUserBackupAccess">Backup</label>
                                     </div>
                                     <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" id="checkboxNewUserCheatAccess" checked>
+                                        <label class="form-check-label" for="checkboxNewUserCheatAccess">Cheats</label>
+                                    </div>
+                                    <div class="form-check">
                                         <input class="form-check-input" type="checkbox" id="checkboxNewUserAdminAccess">
                                         <label class="form-check-label" for="checkboxNewUserAdminAccess">Admin</label>
                                     </div>
@@ -168,6 +172,10 @@
                                         <div class="form-check">
                                             <input class="form-check-input" type="checkbox" id="checkboxEditUserBackupAccess">
                                             <label class="form-check-label" for="checkboxEditUserBackupAccess">Backup</label>
+                                        </div>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="checkboxEditUserCheatAccess">
+                                            <label class="form-check-label" for="checkboxEditUserCheatAccess">Cheats</label>
                                         </div>
                                         <div class="form-check">
                                             <input class="form-check-input" type="checkbox" id="checkboxEditUserAdminAccess">
@@ -465,8 +473,8 @@
     }
 
     function _permsScore(user) {
-        // Sort admins first, then shop, then backup.
-        return (user['admin_access'] ? 4 : 0) + (user['shop_access'] ? 2 : 0) + (user['backup_access'] ? 1 : 0);
+        // Sort admins first, then shop, cheat access, and backup.
+        return (user['admin_access'] ? 8 : 0) + (user['shop_access'] ? 4 : 0) + (user['cheat_access'] ? 2 : 0) + (user['backup_access'] ? 1 : 0);
     }
 
     const RATING_LABELS = { '0': 'E', '10': 'E10+', '13': 'T', '17': 'M', '18': 'AO' };
@@ -668,6 +676,7 @@
             const isAdmin = !!user['admin_access'];
             const isShop = !!user['shop_access'];
             const isBackup = !!user['backup_access'];
+            const isCheat = !!user['cheat_access'];
 
             let badges = '';
             if (user['frozen']) {
@@ -681,6 +690,9 @@
             }
             if (isBackup) {
                 badges += '<span class="badge text-bg-info me-1">Backup</span>';
+            }
+            if (isCheat) {
+                badges += '<span class="badge text-bg-primary me-1">Cheats</span>';
             }
             if (!badges) {
                 badges = '<span class="badge text-bg-secondary">None</span>';
@@ -714,7 +726,7 @@
                 + '<div class="user-actions">'
                 + '<button type="button" class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#editUserModal" data-bs-title="Modify user" data-bs-placement="top"'
                 + ' data-bs-id="' + user['id'] + '" data-bs-user="' + _escapeHtml(user['user']) + '"'
-                + ' data-bs-admin="' + user['admin_access'] + '" data-bs-shop="' + user['shop_access'] + '" data-bs-backup="' + user['backup_access'] + '"'
+                + ' data-bs-admin="' + user['admin_access'] + '" data-bs-shop="' + user['shop_access'] + '" data-bs-backup="' + user['backup_access'] + '" data-bs-cheats="' + user['cheat_access'] + '"'
                 + ' data-bs-max-rating="' + (user['max_rating'] === null || user['max_rating'] === undefined ? '' : user['max_rating']) + '">'
                 + '<i class="bi bi-pencil-square"></i></button>'
                 + '<button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#userHistoryModal" data-bs-title="View history" data-bs-placement="top"'
@@ -854,9 +866,11 @@
         if (this.checked != false) {
             $('#checkboxNewUserShopAccess').prop('checked', true).attr("disabled", true);
             $('#checkboxNewUserBackupAccess').prop('checked', true).attr("disabled", true);
+            $('#checkboxNewUserCheatAccess').prop('checked', true).attr("disabled", true);
         } else {
             $('#checkboxNewUserShopAccess').attr("disabled", false);
             $('#checkboxNewUserBackupAccess').attr("disabled", false);
+            $('#checkboxNewUserCheatAccess').attr("disabled", false);
         }
     });
 
@@ -864,9 +878,11 @@
         if (this.checked != false) {
             $('#checkboxEditUserShopAccess').prop('checked', true).attr("disabled", true);
             $('#checkboxEditUserBackupAccess').prop('checked', true).attr("disabled", true);
+            $('#checkboxEditUserCheatAccess').prop('checked', true).attr("disabled", true);
         } else {
             $('#checkboxEditUserShopAccess').attr("disabled", false);
             $('#checkboxEditUserBackupAccess').attr("disabled", false);
+            $('#checkboxEditUserCheatAccess').attr("disabled", false);
         }
     });
 
@@ -876,6 +892,7 @@
         const password = getInputVal("inputNewUserPassword") || '';
         const shop_access = getCheckboxStatus("checkboxNewUserShopAccess");
         const backup_access = getCheckboxStatus("checkboxNewUserBackupAccess");
+        const cheat_access = getCheckboxStatus("checkboxNewUserCheatAccess");
         const admin_access = getCheckboxStatus("checkboxNewUserAdminAccess");
 
         if (!user) {
@@ -910,6 +927,7 @@
             password: password,
             shop_access: shop_access,
             backup_access: backup_access,
+            cheat_access: cheat_access,
             admin_access: admin_access,
             max_rating: max_rating,
         }
@@ -945,6 +963,7 @@
             const adminAccess = button.getAttribute('data-bs-admin') === 'true'
             const shopAccess = button.getAttribute('data-bs-shop') === 'true'
             const backupAccess = button.getAttribute('data-bs-backup') === 'true'
+            const cheatAccess = button.getAttribute('data-bs-cheats') === 'true'
             const maxRating = button.getAttribute('data-bs-max-rating')
 
             setInputVal("editUserNameInput", editOriginalUser)
@@ -954,19 +973,23 @@
             $("#checkboxEditUserAdminAccess").prop("checked", adminAccess)
             $("#checkboxEditUserShopAccess").prop("checked", adminAccess || shopAccess)
             $("#checkboxEditUserBackupAccess").prop("checked", adminAccess || backupAccess)
+            $("#checkboxEditUserCheatAccess").prop("checked", adminAccess || cheatAccess)
 
             if (adminAccess) {
                 $("#checkboxEditUserShopAccess").prop('checked', true).attr("disabled", true);
                 $("#checkboxEditUserBackupAccess").prop('checked', true).attr("disabled", true);
+                $("#checkboxEditUserCheatAccess").prop('checked', true).attr("disabled", true);
             } else {
                 $("#checkboxEditUserShopAccess").attr("disabled", false);
                 $("#checkboxEditUserBackupAccess").attr("disabled", false);
+                $("#checkboxEditUserCheatAccess").attr("disabled", false);
             }
             $("#editUserNameInput").attr("disabled", false);
             $("#checkboxEditUserAdminAccess").attr("disabled", false);
             if (!adminAccess) {
                 $("#checkboxEditUserShopAccess").attr("disabled", false);
                 $("#checkboxEditUserBackupAccess").attr("disabled", false);
+                $("#checkboxEditUserCheatAccess").attr("disabled", false);
             }
             $('#editUserNameInput').removeClass('is-invalid');
             $('#editUserNameFeedback').text('Username is required.');
@@ -979,6 +1002,7 @@
         const user = (getInputVal("editUserNameInput") || '').trim();
         const shop_access = getCheckboxStatus("checkboxEditUserShopAccess")
         const backup_access = getCheckboxStatus("checkboxEditUserBackupAccess")
+        const cheat_access = getCheckboxStatus("checkboxEditUserCheatAccess")
         const admin_access = getCheckboxStatus("checkboxEditUserAdminAccess")
 
         if (!user) {
@@ -1006,6 +1030,7 @@
             user: user,
             shop_access: shop_access,
             backup_access: backup_access,
+            cheat_access: cheat_access,
             admin_access: admin_access,
             max_rating: max_rating,
         }

--- a/tests/test_cheat_access.py
+++ b/tests/test_cheat_access.py
@@ -1,0 +1,17 @@
+import unittest
+
+from app.db import User
+
+
+class CheatAccessTests(unittest.TestCase):
+    def test_cheat_access_requires_shop_and_cheat_permissions(self):
+        user = User(shop_access=True, cheat_access=True, frozen=False)
+        self.assertTrue(user.has_cheat_access())
+        self.assertTrue(user.has_access('cheats'))
+
+        user.cheat_access = False
+        self.assertFalse(user.has_cheat_access())
+
+        user.cheat_access = True
+        user.frozen = True
+        self.assertFalse(user.has_cheat_access())

--- a/tests/test_cheats.py
+++ b/tests/test_cheats.py
@@ -1,0 +1,59 @@
+import io
+import os
+import shutil
+import unittest
+import zipfile
+
+from app import cheats
+
+
+class CheatStorageTests(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.abspath(os.path.join('.tmp', 'cheat_storage_test'))
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.original_dir = cheats.CHEATS_DIR
+        cheats.CHEATS_DIR = self.test_dir
+
+    def tearDown(self):
+        cheats.CHEATS_DIR = self.original_dir
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_save_list_and_delete_cheat(self):
+        saved = cheats.save_cheat('0100ABCDEF123000', 'A' * 32, b'[Infinite Example]\n04000000 00000000 00000001\n')
+
+        self.assertEqual(saved['title_id'], '0100ABCDEF123000')
+        self.assertEqual(len(cheats.list_cheats()), 1)
+        self.assertEqual(cheats.read_cheat('0100abcdef123000', 'a' * 32)[:9], b'[Infinite')
+        self.assertTrue(cheats.delete_cheat('0100ABCDEF123000', 'A' * 32))
+        self.assertEqual(cheats.list_cheats(), [])
+
+    def test_import_zip_only_accepts_valid_atmosphere_identities(self):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w') as archive:
+            archive.writestr('bundle/0100ABCDEF123000/' + ('B' * 32) + '.txt', '[Example]\n')
+            archive.writestr('0100ABCDEF123000/cheats/' + ('C' * 32) + '.txt', '[Nested Example]\n')
+            archive.writestr('atmosphere/contents/[0100ABCDEF123000]/cheats/' + ('D' * 32) + '-v1.txt', '[Atmosphere Example]\n')
+            archive.writestr('bundle/not-a-title/' + ('C' * 32) + '.txt', '[Ignored]\n')
+            archive.writestr('../0100ABCDEF123000/' + ('E' * 32) + '.txt', '[Safe path]\n')
+
+        result = cheats.import_zip(buffer.getvalue())
+
+        self.assertEqual(result['imported'], 4)
+        self.assertEqual(result['skipped'], 0)
+        self.assertEqual(result['ignored'], 1)
+        self.assertEqual(len(cheats.list_cheats()), 4)
+        self.assertFalse(os.path.exists(os.path.join(os.path.dirname(self.test_dir), '0100ABCDEF123000')))
+
+    def test_rejects_invalid_identifiers_and_non_utf8_content(self):
+        with self.assertRaises(ValueError):
+            cheats.save_cheat('bad', 'A' * 32, b'[Example]')
+        with self.assertRaises(ValueError):
+            cheats.save_cheat('0100ABCDEF123000', 'A' * 32, b'\xff\xfe')
+
+    def test_note_is_stored_with_the_cheat_and_removed_on_delete(self):
+        cheats.save_cheat('0100ABCDEF123000', 'E' * 32, b'[Example]\n')
+        cheats.set_cheat_note('0100ABCDEF123000', 'E' * 32, 'For Example Update')
+
+        self.assertEqual(cheats.list_cheats()[0]['note'], 'For Example Update')
+        cheats.delete_cheat('0100ABCDEF123000', 'E' * 32)
+        self.assertEqual(cheats._load_metadata(), {})


### PR DESCRIPTION
## Summary

Adds a complete cheat-management feature for titles, including admin upload, paste, sync, download, CyberFoil integration, permissions, and library visibility.

## Changes

- Added Cheat Manager for associating cheat files with Title IDs and Build IDs.
- Supports uploading `.txt` files or pasting cheat content.
- Stores cheats as `<BUILD_ID>.txt`, with optional notes.
- Added cheat download and delete actions.
- Added ZIP sync support for common layouts:
  - `<title-id>/<build-id>.txt`
  - `<title-id>/cheats/<build-id>.txt`
  - `atmosphere/contents/<title-id>/cheats/<build-id>.txt`
- Added optional Cheats section in CyberFoil shop settings.
- Added CyberFoil cheat catalogue and download API support.
- Added per-user Cheats permission to allow or deny shop cheat access.
- Added an Available Cheats tab in Library content details beside Updates and DLC.
- Updated README with setup, sync, access, and permission documentation.
- Added a database migration for user cheat access.
- Added focused cheat storage/import and permission tests.