### PR TITLE
Serialize TitleDB update runs to stop concurrent downloads corrupting files

### DIFF
--- a/app/titledb.py
+++ b/app/titledb.py
@@ -5,6 +5,7 @@ import os, re
 import json
 import email.utils
 import logging
+import threading
 import time
 
 from app.constants import *
@@ -337,15 +338,23 @@ def update_titledb_files(app_settings):
         _write_latest_commit(latest_remote_commit)
 
 
-def update_titledb(app_settings):
-    logger.info('Updating titledb...')
-    if not os.path.isdir(TITLEDB_DIR):
-        os.makedirs(TITLEDB_DIR, exist_ok=True)
+# Serializes concurrent runs of update_titledb (scheduled job, TitleDB
+# recovery, settings save). Without it, two runs downloaded into the same
+# fixed <file>.tmp paths and corrupted each other's files. A run that
+# waited here typically finds everything up to date and becomes a cheap
+# no-op.
+_update_titledb_run_lock = threading.Lock()
 
-    try:
-        update_titledb_files(app_settings)
-        logger.info('titledb update done.')
-    except Exception as e:
-        logger.error(f'TitleDB update failed: {e}')
-        logger.warning('TitleDB files may be missing. Some features may not work until TitleDB is successfully downloaded.')
-        raise
+def update_titledb(app_settings):
+    with _update_titledb_run_lock:
+        logger.info('Updating titledb...')
+        if not os.path.isdir(TITLEDB_DIR):
+            os.makedirs(TITLEDB_DIR, exist_ok=True)
+
+        try:
+            update_titledb_files(app_settings)
+            logger.info('titledb update done.')
+        except Exception as e:
+            logger.error(f'TitleDB update failed: {e}')
+            logger.warning('TitleDB files may be missing. Some features may not work until TitleDB is successfully downloaded.')
+            raise

--- a/tests/test_titledb_update_lock.py
+++ b/tests/test_titledb_update_lock.py
@@ -1,0 +1,56 @@
+import threading
+import time
+import unittest
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from app import titledb
+
+
+class TitledbUpdateSerializationTests(unittest.TestCase):
+    def test_concurrent_update_runs_are_serialized(self):
+        active = {"count": 0, "max": 0}
+        counter_lock = threading.Lock()
+
+        def fake_update_files(app_settings):
+            with counter_lock:
+                active["count"] += 1
+                active["max"] = max(active["max"], active["count"])
+            time.sleep(0.05)
+            with counter_lock:
+                active["count"] -= 1
+
+        with TemporaryDirectory() as tmp_dir, patch.object(
+            titledb, "TITLEDB_DIR", tmp_dir
+        ), patch.object(
+            titledb, "update_titledb_files", side_effect=fake_update_files
+        ):
+            threads = [
+                threading.Thread(target=titledb.update_titledb, args=({},))
+                for _ in range(3)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        # Only one run may touch the download/temp files at a time.
+        self.assertEqual(active["max"], 1)
+
+    def test_update_errors_propagate_and_release_the_lock(self):
+        with TemporaryDirectory() as tmp_dir, patch.object(
+            titledb, "TITLEDB_DIR", tmp_dir
+        ), patch.object(
+            titledb, "update_titledb_files", side_effect=ValueError("boom")
+        ):
+            with self.assertRaises(ValueError):
+                titledb.update_titledb({})
+
+        # The lock must be free again for the next run; a non-blocking acquire
+        # fails fast instead of hanging the suite if it ever leaks.
+        self.assertTrue(titledb._update_titledb_run_lock.acquire(blocking=False))
+        titledb._update_titledb_run_lock.release()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First of the PRs from #151 (item 1).

### Symptom

On a fresh install (or whenever TitleDB files go missing), the log reliably shows:

```
ERROR (titledb) TitleDB update failed: Downloaded TitleDB file is invalid: cnmts.json
```

and the install stays without TitleDB data until a later run happens to win the race.

### Root cause

The scheduled update job and the TitleDB recovery path can enter `update_titledb` within a second of each other. `download_titledb_files` downloads every file into a fixed `<file>.tmp` path, so two concurrent runs interleave bytes in the same temp file and delete each other's partial downloads in the `finally` cleanup — validation then fails.

### Fix

A process-wide `threading.Lock` around `update_titledb`. The second caller waits; by the time it enters, files are typically present and `is_titledb_update_available` turns the run into a cheap no-op.

### Tests

`tests/test_titledb_update_lock.py`: mutual exclusion verified with a max-concurrency counter (no timing assertions), plus lock release on error via a non-blocking acquire (fails fast instead of hanging the suite on regression).

### Notes for review

- Blocking (rather than skip) means a titles-settings save that triggers `update_titledb` while the 2-hourly job is mid-download now waits for it instead of corrupting files. Same for the corrupted-file recovery path. If you'd prefer skip-if-running semantics for either caller, happy to adjust.
- The descriptions file (`_ensure_titledb_descriptions_file`) downloads through a separate code path with its own `.tmp` naming and is not covered by this lock; can address that in a follow-up if you want.
