### PR TITLE
Show a retry state on library fetch failure and lazy-load game images

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -635,7 +635,28 @@
                     scrollToResults();
                 }
             })
-            .catch(() => {});
+            .catch(() => {
+                showLoadError();
+            });
+    }
+
+    function showLoadError() {
+        const gameGrid = $('#gameGrid');
+        gameGrid.removeClass('icon-grid list-view').addClass('row g-4');
+        gameGrid.empty();
+        const errorCol = $(`
+            <div class="col-12 text-center py-5">
+                <i class="bi bi-exclamation-triangle text-warning fs-1 d-block mb-3"></i>
+                <p class="text-muted mb-3">Failed to load the game library. The server may still be starting up.</p>
+                <button type="button" class="btn btn-primary library-retry-btn">
+                    <i class="bi bi-arrow-clockwise"></i> Retry
+                </button>
+            </div>
+        `);
+        errorCol.find('.library-retry-btn').on('click', function () {
+            refreshGames();
+        });
+        gameGrid.append(errorCol);
     }
 
     function showLoadingPlaceholders() {
@@ -959,7 +980,7 @@
             const genre = escapeHtml(getPrimaryGenre(game));
             btn.innerHTML = `
                 <div class="discover-tile-body">
-                    <img class="discover-tile-img" src="${iconSrc}" alt="">
+                    <img class="discover-tile-img" src="${iconSrc}" alt="" loading="lazy" decoding="async">
                     <div class="discover-tile-title">${title}</div>
                     <div class="discover-tile-subtitle">${genre}</div>
                 </div>
@@ -1124,7 +1145,10 @@
             const cacheBannerSrc = game.title_id ? `/api/shop/banner/${game.title_id}?size=web` : '';
             const bannerFallback = '/static/placeholder-banner.svg';
             card.attr('data-backdrop-src', cacheBannerSrc || bannerFallback);
-            const img = $('<img class="card-img"></img>').attr('src', cacheBannerSrc || bannerFallback);
+            const img = $('<img class="card-img"></img>')
+                .attr('loading', 'lazy')
+                .attr('decoding', 'async')
+                .attr('src', cacheBannerSrc || bannerFallback);
             img.on('error', function () {
                 if (!this.dataset.triedFallback) {
                     this.dataset.triedFallback = '1';
@@ -1217,7 +1241,7 @@
 
             iconBtn.html(`
                 <div class="discover-tile-body">
-                    <img class="library-icon-img" src="${cacheIconSrc || iconFallback}" alt="">
+                    <img class="library-icon-img" src="${cacheIconSrc || iconFallback}" alt="" loading="lazy" decoding="async">
                     <div class="discover-tile-title" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="${title}">${title}</div>
                     <div class="discover-tile-subtitle">${genre}</div>
                 </div>


### PR DESCRIPTION
From #151 (item 3).

### Symptom

If the `/api/titles` fetch fails (server restarting, transient error), the library page keeps its skeleton placeholders forever — the failure was swallowed by `.catch(() => {})` and the only recovery was a full page reload.

Separately, every game card image loaded eagerly, so a fresh media cache fired the whole page's worth of banner/icon requests at once.

### Fix

- `refreshGames` now renders an error state with a Retry button on real fetch failures. Aborted/superseded requests still resolve quietly (`fetchGames` resolves `false` for those), so the error state only appears for genuine errors.
- The three library image sites (discover tiles, card view, icon view) get `loading="lazy" decoding="async"`, so only viewport images are requested. The existing `error` fallback handlers are unaffected; nothing on the page reads image natural sizes.

No template i18n or backend changes; strings are plain English. Diff is 28 insertions / 4 deletions with the file's original line endings preserved.
