### PR TITLE
Log the query submitted to Prowlarr

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4307,6 +4307,7 @@ def request_prowlarr_search_api():
         timeout_seconds = max(5, min(timeout_seconds, 180))
         search_limit = _get_prowlarr_search_limit(prowlarr_cfg)
         client = ProwlarrClient(prowlarr_cfg['url'], prowlarr_cfg['api_key'], timeout_seconds=timeout_seconds)
+        logger.info(f'Prowlarr search (requests page): "{full_query}" (title {title_id or "-"})')
         results = client.search(
             full_query,
             indexer_ids=prowlarr_cfg.get('indexer_ids') or [],
@@ -5088,6 +5089,7 @@ def downloads_search():
             if suffix and not full_query.lower().endswith(suffix.lower()):
                 full_query = f"{full_query} {suffix}".strip()
         client = ProwlarrClient(prowlarr_cfg['url'], prowlarr_cfg['api_key'], timeout_seconds=timeout_seconds)
+        logger.info(f'Prowlarr search (manual): "{full_query}"')
         results = client.search(
             full_query,
             indexer_ids=prowlarr_cfg.get('indexer_ids') or [],

--- a/app/downloads/manager.py
+++ b/app/downloads/manager.py
@@ -950,6 +950,12 @@ def search_update_options(title_id, version, limit=20):
     min_seeders = _get_torrent_min_seeders(downloads)
     min_age_minutes = _get_usenet_min_age_minutes(downloads)
     for query in query_candidates:
+        logger.info(
+            'Prowlarr search (options): "%s" (title %s v%s)',
+            query,
+            update.get("title_id"),
+            update.get("version"),
+        )
         results = client.search(
             query,
             indexer_ids=prowlarr_cfg.get("indexer_ids") or [],
@@ -1079,6 +1085,12 @@ def _search_and_queue(
     query_candidates = _build_queries(update)
     result = None
     for query in query_candidates:
+        logger.info(
+            'Prowlarr search (queue): "%s" (title %s v%s)',
+            query,
+            update.get("title_id"),
+            update.get("version"),
+        )
         results = client.search(query, indexer_ids=indexer_ids, categories=categories, limit=search_limit)
         result = pick_best_result(
             results,


### PR DESCRIPTION
From #151 (item 4).

### Why

None of the search paths logged the final normalized query submitted to Prowlarr, so a mangled or unexpectedly empty query (e.g. after a display name is stripped by ASCII normalization) was invisible — searches just silently returned nothing useful.

### Fix

INFO log lines at all four `client.search` call sites, each tagged with its origin so a log reader can tell the paths apart:

- `Prowlarr search (options): "..." (title X vY)` — update options search (details modal)
- `Prowlarr search (queue): "..." (title X vY)` — automatic/queueing search
- `Prowlarr search (requests page): "..." (title X)` — requests page
- `Prowlarr search (manual): "..."` — free-text downloads search

Logging only — no control flow, data, or return values touched (14 pure insertions). Queries are already ASCII-normalized before these lines, and no credentials appear in them.
