### PR TITLE
Let the update search list options without a download client

### DIFF
--- a/app/downloads/manager.py
+++ b/app/downloads/manager.py
@@ -922,11 +922,12 @@ def search_update_options(title_id, version, limit=20):
     settings = load_settings()
     downloads = settings.get("downloads", {})
     prowlarr_cfg = downloads.get("prowlarr", {})
+    # Listing options only needs Prowlarr; a download client is required to
+    # queue, and queue_download_url reports that clearly at that point. With
+    # no client configured the protocol filter simply is not applied.
     allowed_protocols = _get_configured_protocols(downloads)
     if not prowlarr_cfg.get("url") or not prowlarr_cfg.get("api_key"):
         return False, "Prowlarr is not configured.", []
-    if not allowed_protocols:
-        return False, "No download client is configured.", []
 
     title_name = title_id
     titles_lib.load_titledb()

--- a/tests/test_search_update_options_no_client.py
+++ b/tests/test_search_update_options_no_client.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch
+
+from app.downloads import manager
+
+
+class SearchUpdateOptionsWithoutClientTests(unittest.TestCase):
+    def test_search_lists_results_with_only_prowlarr_configured(self):
+        fake_results = [{
+            'title': 'Game [0100AAAA00000000][v65536]',
+            'indexer': 'idx',
+            'size': 100,
+            'seeders': 5,
+            'leechers': 0,
+            'download_url': 'magnet:?xt=urn:btih:abc',
+            'protocol': 'torrent',
+            'age_minutes': 99999,
+            'age_label': 'old',
+            'published_at': None,
+        }]
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def search(self, *args, **kwargs):
+                return list(fake_results)
+
+        with patch.object(manager, 'ProwlarrClient', FakeClient), patch.object(
+            manager, 'load_settings',
+            return_value={'downloads': {'prowlarr': {'url': 'http://prowlarr', 'api_key': 'key'}}},
+        ), patch.object(manager.titles_lib, 'load_titledb'), patch.object(
+            manager.titles_lib, 'release_titledb'
+        ), patch.object(
+            manager.titles_lib, 'get_game_info', return_value={'name': 'Game'}
+        ):
+            ok, message, results = manager.search_update_options('0100AAAA00000000', 65536)
+
+        self.assertTrue(ok)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['protocol'], 'torrent')
+
+    def test_search_still_requires_prowlarr(self):
+        with patch.object(manager, 'load_settings', return_value={'downloads': {}}):
+            ok, message, results = manager.search_update_options('0100AAAA00000000', 65536)
+
+        self.assertFalse(ok)
+        self.assertEqual(message, 'Prowlarr is not configured.')
+        self.assertEqual(results, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
From #151 (item 5); related to the inconsistency reported in #138.

### Symptom

With Prowlarr configured but no torrent/usenet client, the details-modal "search update" flow refuses with *"No download client is configured."* — while the free-text `/api/downloads/search` endpoint happily searches in the same setup.

### Fix

Drop the pre-search gate in `search_update_options`: listing results only needs Prowlarr. `allowed_protocols` still flows through, and with no clients configured `pick_best_result` simply applies no protocol filter (verified: empty list means "no filter", not "reject everything"). Queueing still fails clearly at `queue_download_url` ("No torrent/usenet client is configured."), which is where the requirement actually lives.

`manual_search_update` (which queues directly) intentionally keeps its gate — failing before a pointless Prowlarr round-trip is correct there.

### Tests

`tests/test_search_update_options_no_client.py`: a Prowlarr-only search returns results (only external boundaries mocked; fails on current dev without the fix), and the Prowlarr-not-configured error is preserved.
