### PR TITLE
Batch the watcher's deleted-file handling into one dispatch and transaction

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2296,13 +2296,12 @@ def on_library_change(events):
         created_events = [e for e in events if e.type == 'created']
         modified_events = [e for e in events if e.type != 'created']
 
+        deleted_paths = []
         for event in modified_events:
             if event.type == 'moved':
                 moved_outside_library = not event.dest_path or not event.dest_path.startswith(event.directory)
                 if moved_outside_library:
-                    if file_exists_in_db(event.src_path):
-                        has_changes = True
-                    delete_file_by_filepath(event.src_path)
+                    deleted_paths.append(event.src_path)
                     continue
                 if file_exists_in_db(event.src_path):
                     # update the path
@@ -2314,10 +2313,7 @@ def on_library_change(events):
                     created_events.append(event)
 
             elif event.type == 'deleted':
-                # delete the file from library if it exists
-                if file_exists_in_db(event.src_path):
-                    has_changes = True
-                delete_file_by_filepath(event.src_path)
+                deleted_paths.append(event.src_path)
 
             elif event.type == 'modified':
                 # can happen if file copy has started before the app was running
@@ -2325,6 +2321,26 @@ def on_library_change(events):
                     continue
                 add_files_to_library(event.directory, [event.src_path])
                 has_changes = True
+
+        if deleted_paths:
+            # One transaction for the whole event batch: per-event deletes paid
+            # an existence query plus a commit (and fsync) per file, which made
+            # mass deletions crawl through the watcher one file at a time.
+            unique_deleted = list(dict.fromkeys(deleted_paths))
+            try:
+                deleted_count, apps_updated = delete_files_by_filepaths_batch(unique_deleted, commit=True)
+            except Exception as e:
+                # Keep the watcher thread alive; the periodic scan reconciles
+                # anything this batch failed to remove.
+                db.session.rollback()
+                logger.error(f"Failed to remove deleted files from the database: {e}")
+                deleted_count, apps_updated = 0, 0
+            if deleted_count > 0:
+                has_changes = True
+                logger.info(
+                    f"Removed {deleted_count} deleted files from the database "
+                    f"({apps_updated} app references updated)."
+                )
 
         if created_events:
             directories = list(set(e.directory for e in created_events))

--- a/app/file_watcher.py
+++ b/app/file_watcher.py
@@ -1,5 +1,6 @@
 from app.constants import *
 from app.utils import *
+import threading
 import time, os
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
@@ -33,6 +34,12 @@ class Watcher:
         logger.debug('Stopping observer...')
         self.observer.stop()
         self.observer.join()
+        # Best effort: dispatch any deletions still buffered for the debounced
+        # flush so a clean shutdown does not drop them.
+        try:
+            self.event_handler._flush_deleted_events()
+        except Exception:
+            logger.exception('Failed to flush pending deleted events on stop')
         logger.debug('Successfully stopped observer.')
 
     def add_directory(self, directory):
@@ -63,12 +70,22 @@ class Watcher:
         return False
 
 class Handler(FileSystemEventHandler):
-    def __init__(self, callback, stability_duration=5):
+    def __init__(self, callback, stability_duration=5, delete_batch_window=2):
         self._raw_callback = callback  # Callback to invoke for stable files
         self.directories = []
         self.stability_duration = stability_duration  # Stability duration in seconds
         self.tracked_files = {}  # Tracks files being copied
         self.debounced_check_final = self._debounce(self._check_file_stability, stability_duration)
+        # Deleted events are coalesced into one callback per burst so a mass
+        # deletion does not dispatch (and hit the database) one file at a time.
+        # The window is shorter than stability_duration, so a delete followed
+        # by a re-create of the same path is normally processed in order; the
+        # flush is trailing-only, so a sustained delete stream can postpone it
+        # past a re-create's stabilization — the periodic scan reconciles that
+        # rare case, as it already does for events lost while not running.
+        self.pending_deleted_events = []
+        self._pending_deleted_lock = threading.Lock()
+        self.debounced_flush_deleted = self._debounce(self._flush_deleted_events, delete_batch_window)
 
     def add_directory(self, directory):
         if directory not in self.directories:
@@ -99,6 +116,14 @@ class Handler(FileSystemEventHandler):
         else:
             self.tracked_files[file_path].size = current_size
             self.tracked_files[file_path].timestamp = time.time()
+
+    def _flush_deleted_events(self):
+        """Dispatch every buffered deleted event as a single batch."""
+        with self._pending_deleted_lock:
+            batch = self.pending_deleted_events
+            self.pending_deleted_events = []
+        if batch:
+            self._raw_callback(batch)
 
     def _check_file_stability(self):
         """Check for stable files and invoke the callback."""
@@ -142,7 +167,9 @@ class Handler(FileSystemEventHandler):
             library_event.type = 'deleted'
 
         if library_event.type == 'deleted':
-            self._raw_callback([library_event])
+            with self._pending_deleted_lock:
+                self.pending_deleted_events.append(library_event)
+            self.debounced_flush_deleted()
 
         else:
             # Track file on create or modify

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -29,6 +29,7 @@ class FileWatcherTests(unittest.TestCase):
         callback_events = []
         handler = Handler(callback_events.extend, stability_duration=5)
         handler.debounced_check_final = lambda: None
+        handler.debounced_flush_deleted = lambda: None
         with patch.object(handler, "_check_file_stability") as check_mock:
             handler.collect_event(
                 SimpleNamespace(
@@ -40,6 +41,39 @@ class FileWatcherTests(unittest.TestCase):
                 "X:\\library",
             )
 
+        # Deleted events are buffered until the debounced flush fires.
+        self.assertEqual(len(callback_events), 0)
+        self.assertEqual(len(handler.pending_deleted_events), 1)
+        self.assertEqual(handler.pending_deleted_events[0].type, "deleted")
+        handler._flush_deleted_events()
         self.assertEqual(len(callback_events), 1)
         self.assertEqual(callback_events[0].type, "deleted")
         check_mock.assert_called_once()
+
+    def test_deleted_events_coalesce_into_one_batch(self):
+        batches = []
+        handler = Handler(batches.append, stability_duration=5)
+        handler.debounced_check_final = lambda: None
+        handler.debounced_flush_deleted = lambda: None
+        with patch.object(handler, "_check_file_stability"):
+            for name in ("A.nsp", "B.nsp"):
+                handler.collect_event(
+                    SimpleNamespace(
+                        is_directory=False,
+                        event_type="deleted",
+                        src_path=f"X:\\library\\{name}",
+                        dest_path="",
+                    ),
+                    "X:\\library",
+                )
+
+        self.assertEqual(batches, [])
+        handler._flush_deleted_events()
+        self.assertEqual(len(batches), 1)
+        self.assertEqual(
+            [event.src_path for event in batches[0]],
+            ["X:\\library\\A.nsp", "X:\\library\\B.nsp"],
+        )
+        # An empty buffer must not dispatch another callback.
+        handler._flush_deleted_events()
+        self.assertEqual(len(batches), 1)

--- a/tests/test_watcher_deleted_batch.py
+++ b/tests/test_watcher_deleted_batch.py
@@ -1,0 +1,47 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.app import on_library_change
+
+
+def _event(event_type, src_path, directory='/games', dest_path=None):
+    return SimpleNamespace(
+        type=event_type,
+        src_path=src_path,
+        dest_path=dest_path,
+        directory=directory,
+    )
+
+
+class WatcherDeletedBatchTests(unittest.TestCase):
+    @patch('app.app.post_library_change')
+    @patch('app.app.delete_files_by_filepaths_batch', return_value=(3, 3))
+    def test_deleted_events_are_cleared_in_one_batch(self, batch_mock, post_mock):
+        events = [
+            _event('deleted', '/games/a.nsp'),
+            _event('deleted', '/games/b.nsp'),
+            # Watchdog can emit duplicate events for the same path.
+            _event('deleted', '/games/a.nsp'),
+            # Moves out of the library are deletions from the library's view.
+            _event('moved', '/games/c.nsp', dest_path='/outside/c.nsp'),
+        ]
+
+        on_library_change(events)
+
+        batch_mock.assert_called_once_with(
+            ['/games/a.nsp', '/games/b.nsp', '/games/c.nsp'], commit=True
+        )
+        post_mock.assert_called_once_with()
+
+    @patch('app.app.post_library_change')
+    @patch('app.app.delete_files_by_filepaths_batch', return_value=(0, 0))
+    def test_no_rebuild_when_nothing_was_in_the_database(self, batch_mock, post_mock):
+        on_library_change([_event('deleted', '/games/unknown.nsp')])
+
+        batch_mock.assert_called_once_with(['/games/unknown.nsp'], commit=True)
+        post_mock.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
From #151 (item 2), with the regression test you asked for.

### Symptom

Mass deletions crawl through the watcher one file at a time: every deleted event is dispatched to `on_library_change` immediately as its own single-event callback, and each callback runs an existence query plus a single-file delete transaction — one fsync per file.

### Fix

Two halves, mirroring the batching the stability path already does for created/modified events:

- **Handler** buffers deleted events and dispatches each burst as one batch via a short debounced flush (`delete_batch_window=2s`, shorter than `stability_duration`, so a delete followed by a re-create of the same path is normally processed in order; the rare pathological interleaving is reconciled by the periodic scan, as noted in the code comment). `Watcher.stop` flushes the buffer best-effort on clean shutdown.
- **`on_library_change`** collects the batch's deleted/moved-away paths and clears them with a single `delete_files_by_filepaths_batch` call plus one summary log line, wrapped in try/except + rollback so a database error can no longer kill the dispatching thread with a dirty session (the old path went through `delete_file_by_filepath`, which had that protection).

`has_changes` semantics are preserved: the batch helper returns the count of rows actually deleted, which is >0 iff any path existed — equivalent to the old per-path `file_exists_in_db` checks, duplicates included.

### Tests

- `tests/test_file_watcher.py`: deleted events buffer instead of dispatching immediately; a burst coalesces into one ordered batch; an empty flush dispatches nothing (existing move-to-unsupported test updated for the new contract).
- `tests/test_watcher_deleted_batch.py`: the regression test you asked for — a batch of deleted paths (including a duplicate event and a move out of the library) hits the database as exactly one batched call; and no rebuild is scheduled when nothing was actually removed.
