### PR TITLE
Defer watchdog directory registration off the startup path

### DIFF
--- a/app/library.py
+++ b/app/library.py
@@ -181,6 +181,14 @@ def remove_library_complete(app, watcher, path):
         return success, errors
 
 def init_libraries(app, watcher, paths):
+    # watcher.add_directory() does one inotify_add_watch() syscall per directory in the tree -
+    # on a large NFS-backed library (thousands of directories) that's minutes of blocking I/O.
+    # This function used to run entirely synchronously inside init(), before waitress opened its
+    # port, so a slow library meant the app was unreachable (and its startupProbe was fighting
+    # the clock) on every single restart. The DB bookkeeping below is cheap (plain inserts), so
+    # keep that synchronous - it has to finish before the scheduler's startup scan job runs, or
+    # that job finds no registered libraries and does nothing until its next interval. Only the
+    # actual watchdog registration is deferred to a background thread.
     with app.app_context():
         # delete non existing libraries
         for library in get_libraries():
@@ -190,17 +198,17 @@ def init_libraries(app, watcher, paths):
                 # Use the complete removal function for consistency
                 remove_library_complete(app, watcher, path)
 
-        # add libraries and start watchdog
+        # add libraries to the database
         for path in paths:
             # Check if library already exists in database
             existing_library = Libraries.query.filter_by(path=path).first()
             if not existing_library:
-                # add library paths to watchdog if necessary
-                watcher.add_directory(path)
                 add_library(path)
-            else:
-                # Ensure watchdog is monitoring existing library
-                watcher.add_directory(path)
+
+    def _register_watchdog_directories():
+        for path in paths:
+            watcher.add_directory(path)
+    threading.Thread(target=_register_watchdog_directories, daemon=True).start()
 
 def add_files_to_library(library, files, check_existing=True):
     nb_to_identify = len(files)


### PR DESCRIPTION
`init_libraries()` calls `watcher.add_directory(path)` synchronously inside `init()`, which runs before `waitress_serve()` opens the HTTP port. `add_directory()` does one `inotify_add_watch()` syscall per directory in the tree (`Observer.schedule(..., recursive=True)`) - on a large NFS-backed library (tens of thousands of directories) that's minutes of blocking I/O on every single restart, during which the app is completely unreachable and its startupProbe (in a container deployment) is racing the clock.

Confirmed live: a ~13k-file / ~11.6k-directory Switch library took anywhere from ~1 to ~25 minutes on this step across different restarts (NFS latency variance, not CPU - it sat near-zero CPU the whole time), with no way to distinguish "still registering" from "hung" without watching CPU/logs directly.

Fix: keep the DB bookkeeping in `init_libraries()` synchronous (it's cheap plain inserts, and has to finish before the scheduler's `update_db_and_scan` startup job runs or that job finds no registered libraries and does nothing until its next 2h interval) - but move the actual `watcher.add_directory()` calls to a background thread. The app becomes reachable immediately; live file-change detection comes online a little later instead of gating the whole boot.

Tested against the same library that produced the slow real-world timings above.

Related, not included here since it's a separate question of whether live watching is worth keeping at all: the scheduled `update_db_and_scan` job already does its own independent full scan (`os.walk`-based, not inotify) regardless of watcher state, so for deployments where live change detection isn't critical, skipping the inotify registration entirely and relying on the scheduled scan might be simpler than deferring it. Happy to open that as a separate config-gated PR if there's interest.